### PR TITLE
Fix: API Proxy and Exception Handling

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -20,5 +20,16 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        // Handle unauthenticated API requests - return JSON instead of redirecting to login
+        $exceptions->render(function (\Illuminate\Auth\AuthenticationException $e, \Illuminate\Http\Request $request) {
+            if ($request->is('api/*') || $request->expectsJson()) {
+                return response()->json(['message' => 'Unauthenticated.'], 401);
+            }
+        });
+        // Browser requests to API also trigger RouteNotFoundException when no login route exists
+        $exceptions->render(function (\Symfony\Component\Routing\Exception\RouteNotFoundException $e, \Illuminate\Http\Request $request) {
+            if ($request->is('api/*')) {
+                return response()->json(['message' => 'Unauthenticated.'], 401);
+            }
+        });
     })->create();

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -8,7 +8,14 @@ const withSerwist = withSerwistInit({
 });
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8000/api/:path*',
+      },
+    ];
+  },
 };
 
 export default withSerwist(nextConfig);


### PR DESCRIPTION
Summary of changes:
- Frontend: Added Next.js rewrites to proxy /api/* to the local backend port 8000.
- Backend: Updated exception handling in ootstrap/app.php to return JSON 401 instead of redirecting to a non-existent login route for API requests.
- This allows for easier testing from mobile devices via a single ngrok tunnel.